### PR TITLE
fix x64 build

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -60,7 +60,7 @@ jobs:
     # Restore the application to populate the obj folder with RuntimeIdentifiers
     - name: Restore the application
       if: env.Wpf_build == 'true' 
-      run: dotnet restore ${{ env.Wpf_Project_Path }}/${{ env.Wpf_Project_Path }}.csproj
+      run: dotnet restore ${{ env.Wpf_Project_Path }}/${{ env.Wpf_Project_Path }}.csproj -r win-${{matrix.targetplatform}}
       env:
         Configuration: ${{ matrix.configuration }}
 
@@ -81,7 +81,7 @@ jobs:
     # Publish the Wap package
     - name: Publish the Wpf package
       if: github.event_name != 'pull_request' && env.Wpf_build == 'true'
-      run: dotnet publish ${{ env.Wpf_Project_Path }} --no-restore -c ${{ matrix.configuration }} --self-contained true -r win-x64 -o ./published
+      run: dotnet publish ${{ env.Wpf_Project_Path }} --no-restore -c ${{ matrix.configuration }} --self-contained true -r win-${{matrix.targetplatform}} -o ./published
 
     # Upload the published app as an artifact
     - name: Upload artifact

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -80,7 +80,7 @@ jobs:
 
     # Publish the Wap package
     - name: Publish the Wpf package
-      # if: github.event_name != 'pull_request' && env.Wpf_build == 'true'
+      if: github.event_name != 'pull_request' && env.Wpf_build == 'true'
       run: dotnet publish ${{ env.Wpf_Project_Path }} --no-restore -c ${{ matrix.configuration }} --self-contained true -r win-${{matrix.targetplatform}} -o ./published
 
     # Upload the published app as an artifact

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -80,7 +80,7 @@ jobs:
 
     # Publish the Wap package
     - name: Publish the Wpf package
-      if: github.event_name != 'pull_request' && env.Wpf_build == 'true'
+      # if: github.event_name != 'pull_request' && env.Wpf_build == 'true'
       run: dotnet publish ${{ env.Wpf_Project_Path }} --no-restore -c ${{ matrix.configuration }} --self-contained true -r win-${{matrix.targetplatform}} -o ./published
 
     # Upload the published app as an artifact


### PR DESCRIPTION
fix for

```
Run dotnet publish KeyboardMouseWin --no-restore -c Release --self-contained true -r win-x64 -o ./published
MSBuild version 17.9.6+a4ecab324 for .NET
D:\a\KeyboardMouse\KeyboardMouse\KeyboardMouseWin\KeyboardMouseWin.csproj : warning NU1701: Package 'FontAwesome.WPF 4.7.0.9' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8, .NETFramework,Version=v4.8.1' instead of the project target framework 'net8.0-windows7.0'. This package may not be fully compatible with your project.
Error: C:\Program Files\dotnet\sdk\8.0.[20](https://github.com/sfetzel/KeyboardMouse/actions/runs/8411997284/job/23032278897#step:10:21)3\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(491,5): error NETSDK1112: The runtime pack for Microsoft.NETCore.App.Runtime.win-x64 was not downloaded. Try running a NuGet restore with the RuntimeIdentifier 'win-x64'. [D:\a\KeyboardMouse\KeyboardMouse\KeyboardMouseWin\KeyboardMouseWin.csproj]
Error: C:\Program Files\dotnet\sdk\8.0.203\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.Sdk.FrameworkReferenceResolution.targets(491,5): error NETSDK1112: The runtime pack for Microsoft.WindowsDesktop.App.Runtime.win-x64 was not downloaded. Try running a NuGet restore with the RuntimeIdentifier 'win-x64'. [D:\a\KeyboardMouse\KeyboardMouse\KeyboardMouseWin\KeyboardMouseWin.csproj]
Error: Process completed with exit code 1.
```